### PR TITLE
add metadata as requested by Quicklisp maintainer

### DIFF
--- a/cl-lex.asd
+++ b/cl-lex.asd
@@ -20,6 +20,9 @@
 
 (asdf:defsystem :cl-lex
   :version "1.1.3"
+  :author "David J. Rosenbaum <djr7C4@gmail.com>"
+  :license "GPL3"
+  :description "Common Lisp macros for generating lexical analyzers"
   :serial t
   :components ((:file "packages")
 	       (:file "lex"))


### PR DESCRIPTION
Quicklisp now gets CL-Lex directly from github, not from an old tarball,
but the Quicklisp maintainer asked to update the metadata in the .asd file.

Fixes quicklisp/quicklisp-projects#1192.
